### PR TITLE
Fixed a bug encoding multiple polylines in a row

### DIFF
--- a/PolyUtil.php
+++ b/PolyUtil.php
@@ -367,7 +367,7 @@ class PolyUtil {
         $lastLat = 0;
         $lastLng = 0;
 
-        $result = '';
+        self::$result = '';
 
         foreach( $path as $point ) {
             $lat = round( $point['lat'] * 1e5);


### PR DESCRIPTION
Tried encoding multiple polylines using a for loop. PHP would run out of memory because previously encoded polylines were being stored.